### PR TITLE
updated sanitizer, lru_cache

### DIFF
--- a/apptuit/timeseries.py
+++ b/apptuit/timeseries.py
@@ -4,6 +4,11 @@
 
 import json
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 
 def encode_metric(metric_name, metric_tags):
     """
@@ -28,6 +33,7 @@ def encode_metric(metric_name, metric_tags):
     return encoded_metric_name
 
 
+@lru_cache(maxsize=2000)
 def decode_metric(encoded_metric_name):
     """
     Decode the metric name as encoded by encode_metric_name

--- a/apptuit/utils.py
+++ b/apptuit/utils.py
@@ -19,7 +19,7 @@ APPTUIT_SANITIZE_REGEX = re.compile(r'([^-\w_./])', re.U)
 REPLACE_WITH_SINGLE_UNDERSCORE_REGEX = re.compile('_+')
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=2000)
 def sanitize_name_prometheus(name):
     """
     To make the metric name Prometheus compatible.
@@ -36,7 +36,7 @@ def sanitize_name_prometheus(name):
     return REPLACE_WITH_SINGLE_UNDERSCORE_REGEX.sub("_", name)
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=2000)
 def sanitize_name_apptuit(name):
     """
     To make the metric name Apptuit compatible.
@@ -48,7 +48,7 @@ def sanitize_name_apptuit(name):
     return REPLACE_WITH_SINGLE_UNDERSCORE_REGEX.sub("_", substitute_string)
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=2000)
 def _contains_valid_chars(string):
     return VALID_REGEX.match(string) is not None
 

--- a/tests/test_pyformance_reporter.py
+++ b/tests/test_pyformance_reporter.py
@@ -713,11 +713,11 @@ def test_sanitizer_type():
     """
     reporter = ApptuitReporter(sanitize_mode=None, token="test")
     assert_is_none(reporter.client.sanitizer)
-    reporter = ApptuitReporter("prometheus", token="test")
+    reporter = ApptuitReporter(sanitize_mode="prometheus", token="test")
     assert_equals(reporter.client.sanitizer, sanitize_name_prometheus)
-    reporter = ApptuitReporter("apptuit", token="test")
+    reporter = ApptuitReporter(sanitize_mode="apptuit", token="test")
     assert_equals(reporter.client.sanitizer, sanitize_name_apptuit)
-    reporter = ApptuitReporter(None, token="test")
+    reporter = ApptuitReporter(sanitize_mode=None, token="test")
     assert_equals(reporter.client.sanitizer, None)
     with assert_raises(ValueError):
-        ApptuitReporter("unknown", token="test")
+        ApptuitReporter(sanitize_mode="unknown", token="test")

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -14,7 +14,7 @@ from apptuit import Apptuit, DataPoint, TimeSeries, ApptuitException, APPTUIT_PY
 
 def __get_apptuit_client():
     token = "asdashdsauh_8aeraerf"
-    return Apptuit(None, token, api_endpoint="http://localhost")
+    return Apptuit(token, api_endpoint="http://localhost")
 
 
 def test_client_global_tags():

--- a/tests/test_token_and_tags.py
+++ b/tests/test_token_and_tags.py
@@ -34,7 +34,7 @@ def test_token_positive():
     for env_token, arg_token, expected in test_cases:
         mock_environ = patch.dict(os.environ, {APPTUIT_PY_TOKEN: env_token})
         mock_environ.start()
-        client = Apptuit(None, token=arg_token)
+        client = Apptuit(token=arg_token)
         assert_equals(client.token, expected)
         mock_environ.stop()
 
@@ -79,7 +79,7 @@ def test_tags_env_variable_parsing_positive():
     for env_tags_value, expected_global_tags in test_cases:
         mock_environ = patch.dict(os.environ, {APPTUIT_PY_TAGS: env_tags_value})
         mock_environ.start()
-        reporter = ApptuitReporter(None, token=token)
+        reporter = ApptuitReporter(token=token)
         assert_equals(reporter.tags, expected_global_tags)
         mock_environ.stop()
 
@@ -107,7 +107,7 @@ def test_env_tags_with_host_tag_disabled_env():
             mock_environ = patch.dict(os.environ, {APPTUIT_PY_TAGS: env_tags_value,
                                                    DISABLE_HOST_TAG: disable_value})
             mock_environ.start()
-            reporter = ApptuitReporter(None, token=token)
+            reporter = ApptuitReporter(token=token)
             assert_equals(reporter.tags, expected_global_tags)
             mock_environ.stop()
         for disable_value in disable_host_tag_other_values:
@@ -117,7 +117,7 @@ def test_env_tags_with_host_tag_disabled_env():
             if "host" not in expected_global_tags:
                 expected_global_tags["host"] = socket.gethostname()
             mock_environ.start()
-            reporter = ApptuitReporter(None, token=token)
+            reporter = ApptuitReporter(token=token)
             assert_equals(reporter.tags, expected_global_tags)
             mock_environ.stop()
 
@@ -143,7 +143,7 @@ def test_env_tags_with_host_tag_disabled_param():
         for disable_value in disable_host_tag_values:
             mock_environ = patch.dict(os.environ, {APPTUIT_PY_TAGS: env_tags_value})
             mock_environ.start()
-            reporter = ApptuitReporter(None, token=token, disable_host_tag=disable_value)
+            reporter = ApptuitReporter(token=token, disable_host_tag=disable_value)
             if disable_value is None or disable_value is False:
                 if expected_global_tags:
                     if "host" not in expected_global_tags:
@@ -161,11 +161,11 @@ def test_token_negative():
     mock_environ = patch.dict(os.environ, {})
     mock_environ.start()
     with assert_raises(ValueError):
-        Apptuit(None, )
+        Apptuit()
     with assert_raises(ValueError):
-        Apptuit(None, token="")
+        Apptuit(token="")
     with assert_raises(ValueError):
-        Apptuit(None, token=None)
+        Apptuit(token=None)
     mock_environ.stop()
 
 
@@ -176,13 +176,13 @@ def test_env_global_tags_positive():
     mock_environ = patch.dict(os.environ, {APPTUIT_PY_TOKEN: "environ_token",
                                            APPTUIT_PY_TAGS: 'tagk1: 22, tagk2: tagv2'})
     mock_environ.start()
-    client = Apptuit(None, )
+    client = Apptuit()
     assert_equals(client._global_tags, {"tagk1": "22", "tagk2": "tagv2"})
     mock_environ.stop()
 
     mock_environ = patch.dict(os.environ, {APPTUIT_PY_TOKEN: "environ_token"})
     mock_environ.start()
-    client1 = Apptuit(None, )
+    client1 = Apptuit()
     assert_equals({}, client1._global_tags)
     mock_environ.stop()
 
@@ -195,13 +195,13 @@ def test_env_global_tags_negative():
                                            APPTUIT_PY_TAGS: "{InvalidTags"})
     mock_environ.start()
     with assert_raises(ValueError):
-        Apptuit(None, )
+        Apptuit()
     mock_environ.stop()
     mock_environ = patch.dict(os.environ, {APPTUIT_PY_TOKEN: "environ_token",
                                            APPTUIT_PY_TAGS: '"tagk1":"tagv1"'})
     mock_environ.start()
     with assert_raises(ValueError):
-        Apptuit(None, )
+        Apptuit()
     mock_environ.stop()
 
 
@@ -239,7 +239,7 @@ def test_no_environ_tags():
     test_val = math.pi
     mock_environ = patch.dict(os.environ, {APPTUIT_PY_TOKEN: "environ_token"})
     mock_environ.start()
-    client = Apptuit(None, )
+    client = Apptuit()
     dp1 = DataPoint(metric="test_metric", tags={"host": "host2", "ip": "2.2.2.2", "test": 1},
                     timestamp=timestamp, value=test_val)
     dp2 = DataPoint(metric="test_metric", tags={"test": 2}, timestamp=timestamp, value=test_val)
@@ -249,7 +249,7 @@ def test_no_environ_tags():
     assert_equals(payload[1]["tags"], {"test": 2})
 
     registry = MetricsRegistry()
-    reporter = ApptuitReporter(None, registry=registry, tags={"host": "reporter", "ip": "2.2.2.2"})
+    reporter = ApptuitReporter(registry=registry, tags={"host": "reporter", "ip": "2.2.2.2"})
     counter = registry.counter("counter")
     counter.inc(1)
     payload = reporter.client._create_payload_from_datapoints(reporter._collect_data_points(reporter.registry))
@@ -277,13 +277,13 @@ def test_reporter_tags_with_global_env_tags():
                                            APPTUIT_PY_TAGS: 'host: environ, ip: 1.1.1.1'})
     mock_environ.start()
     registry = MetricsRegistry()
-    reporter = ApptuitReporter(None, registry=registry, tags={"host": "reporter", "ip": "2.2.2.2"})
+    reporter = ApptuitReporter(registry=registry, tags={"host": "reporter", "ip": "2.2.2.2"})
     counter = registry.counter("counter")
     counter.inc(1)
     payload = reporter.client._create_payload_from_datapoints(reporter._collect_data_points(reporter.registry))
     assert_equals(len(payload), 1)
     assert_equals(payload[0]["tags"], {'host': 'reporter', 'ip': '2.2.2.2'})
-    reporter = ApptuitReporter(None, registry=registry)
+    reporter = ApptuitReporter(registry=registry)
     counter = registry.counter("counter")
     counter.inc(1)
     payload = reporter.client._create_payload_from_datapoints(reporter._collect_data_points(reporter.registry))
@@ -300,7 +300,7 @@ def test_tags_of_metric_take_priority():
                                            APPTUIT_PY_TAGS: 'host: environ, ip: 1.1.1.1'})
     mock_environ.start()
     registry = MetricsRegistry()
-    reporter = ApptuitReporter(None, registry=registry, tags={"host": "reporter", "ip": "2.2.2.2"})
+    reporter = ApptuitReporter(registry=registry, tags={"host": "reporter", "ip": "2.2.2.2"})
     counter = registry.counter('counter {"host": "metric", "ip": "3.3.3.3"}')
     counter.inc(1)
 
@@ -318,7 +318,7 @@ def test_deprecated_tags_variable():
     with patch.dict(os.environ, {DEPRECATED_APPTUIT_PY_TAGS: 'host: environ, ip: 127.0.0.1'}):
         registry = MetricsRegistry()
         with assert_raises(DeprecationWarning):
-            reporter = ApptuitReporter(None, token="test_token", registry=registry,
+            reporter = ApptuitReporter(token="test_token", registry=registry,
                                        tags={'host': 'reporter'})
     warnings.resetwarnings()
 
@@ -331,6 +331,6 @@ def test_deprecated_token_variable():
     with patch.dict(os.environ, {DEPRECATED_APPTUIT_PY_TOKEN: "test_token"}):
         registry = MetricsRegistry()
         with assert_raises(DeprecationWarning):
-            ApptuitReporter(None, registry=registry,
+            ApptuitReporter(registry=registry,
                             tags={'host': 'reporter'})
     warnings.resetwarnings()


### PR DESCRIPTION
- sanitize_mode is a optional parameter, by default it is set to
prometheus. did it in ApptuitReporter and Apptuit.
- updated tests to work with updated sanitize_mode.
- added lru_cache to TimeSeriesName.decode_metric for better
performance.
- removed __decoded_metrics_cache var from ApptuitReporter.
- updated ApptuitReporter._get_tags to work with new
TimeSeriesName.decode_metric.
- set maxsize of lru_cache to 2000 in all places.